### PR TITLE
Update QuickBaseClient.js

### DIFF
--- a/QuickBaseClient.js
+++ b/QuickBaseClient.js
@@ -758,7 +758,7 @@ function QuickBaseClient( qdbServer )
         var Root = xmlQDBRequest.documentElement;
         var ElementNode = xmlQDBRequest.createElement( "field" );
         var attrField;
-        if ( fieldName.match( /^[1-9]\d*$/ ) )
+        if ( fieldName.toString().match( /^[1-9]\d*$/ ) )
         {
             ElementNode.setAttribute( "fid", fieldName )
         }


### PR DESCRIPTION
When passing fid to "EditRecord" was giving an error because fieldName was numeric. added "toString() to fieldName and now it works properly.
